### PR TITLE
fix(package): update node-red-contrib-bigtimer to version 2.0.8

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -15,7 +15,7 @@
         "node-red": "0.19.5",
         "node-red-contrib-actionflows": "2.0.1",
         "node-red-contrib-alexa-home-skill": "0.1.17",
-        "node-red-contrib-bigtimer": "2.0.3",
+        "node-red-contrib-bigtimer": "2.0.8",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-google-home-notify": "0.0.6",
         "node-red-contrib-home-assistant-websocket": "0.4.0",


### PR DESCRIPTION
Closes #6

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/